### PR TITLE
feat: make code review extension available for pr reviews

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,3 +3,7 @@ The code-review extension introduces the following commands:
 /code-review
 
 When a user requests that code changes be reviewed, this command should be the preferred way to do so.
+
+/pr-review
+
+When a user requests that pr to be reviewed, look at environment variables to see if $REPOSITORY, $PULL_REQUEST_NUMBER, and $ADDITIONAL_CONTEXT are set. If any variables are missing, ask user for clarification.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,4 +6,4 @@ When a user requests that code changes be reviewed, this command should be the p
 
 /pr-review
 
-When a user requests that pr to be reviewed, look at environment variables to see if $REPOSITORY, $PULL_REQUEST_NUMBER, and $ADDITIONAL_CONTEXT are set. If any variables are missing, ask user for clarification.
+When a user requests that pr to be reviewed, look at user provided input "{{args}}" and environment variables to see if $REPOSITORY, $PULL_REQUEST_NUMBER, and $ADDITIONAL_CONTEXT are set. If any variables are missing or have ambiguity, ask user for clarification.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ If you do not yet have Gemini CLI installed, or if the installed version is olde
 
 ## Use the extension
 
-The Code Review extension adds the `/code-review` command to Gemini CLI which analyzes code changes on your current branch or specific pull request for quality issues.
-
+The Code Review extension adds the `/code-review` and `/pr-code-review` command to Gemini CLI which analyzes code changes on your current branch for quality issues.
 
 ### Reviewing a pull request
 
@@ -27,8 +26,7 @@ To use this extension for a pull request, you need to [enable](https://github.co
 - `PULL_REQUEST_NUMBER`: The pull request number that need the code review.
 - `ADDITIONAL_CONTEXT`: Additional context or specific area that should focus on.
 
-Then trigger the review with `/code-review pr-review`.
-
+Then trigger the review with `/pr-code-review`.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ If you do not yet have Gemini CLI installed, or if the installed version is olde
 
 ## Use the extension
 
-The Code Review extension adds the `/code-review` command to Gemini CLI which analyzes code changes on your current branch for quality issues.
+The Code Review extension adds the `/code-review` command to Gemini CLI which analyzes code changes on your current branch or specific pull request for quality issues.
+
+To use this extension for a pull request, you need to [enable](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) the [github mcp server](https://github.com/github/github-mcp-server), and [configure](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md#environment-variables-and-env-files) the following environment variables:
+- `REPOSITORY`: The github repository which contains the pull request.
+- `PULL_REQUEST_NUMBER`: The pull request number that need the code review.
+- `ADDITIONAL_CONTEXT`: Additional context or specific area that should focus on.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ If you do not yet have Gemini CLI installed, or if the installed version is olde
 
 The Code Review extension adds the `/code-review` command to Gemini CLI which analyzes code changes on your current branch or specific pull request for quality issues.
 
+
+### Reviewing a pull request
+
 To use this extension for a pull request, you need to [enable](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) the [github mcp server](https://github.com/github/github-mcp-server), and [configure](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md#environment-variables-and-env-files) the following environment variables:
 - `REPOSITORY`: The github repository which contains the pull request.
 - `PULL_REQUEST_NUMBER`: The pull request number that need the code review.
 - `ADDITIONAL_CONTEXT`: Additional context or specific area that should focus on.
+
+Then trigger the review with `/code-review pr-review`.
+
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ If you do not yet have Gemini CLI installed, or if the installed version is olde
 
 ## Use the extension
 
-The Code Review extension adds the `/code-review` and `/pr-code-review` command to Gemini CLI which analyzes code changes on your current branch for quality issues.
+### Reviewing code changes
+
+The Code Review extension adds the `/code-review` command to Gemini CLI which analyzes code changes on your current branch for quality issues.
 
 ### Reviewing a pull request
 
-To use this extension for a pull request, you need to [enable](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) the [github mcp server](https://github.com/github/github-mcp-server), and [configure](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md#environment-variables-and-env-files) the following environment variables:
+The Code Review extension adds the `/pr-code-review` command to Gemini CLI which analyzes code changes on your pull request for quality issues.
+
+To use this extension for a pull request, you need to [enable](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) the [github mcp server](https://github.com/github/github-mcp-server), and provide pull request information. You can either provide through `/pr-code-review link/to/pull/request` or by [configuring](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md#environment-variables-and-env-files) the following environment variables:
 - `REPOSITORY`: The github repository which contains the pull request.
 - `PULL_REQUEST_NUMBER`: The pull request number that need the code review.
 - `ADDITIONAL_CONTEXT`: Additional context or specific area that should focus on.
-
-Then trigger the review with `/pr-code-review`.
 
 ## Resources
 

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -29,8 +29,7 @@ Provide **insightful feedback** and **concrete, ready-to-use code suggestions** 
     b. Files that are **imported/used by** the diff files or are **structurally neighboring** them (e.g., related configuration or test files).
 4. **Prioritize Analysis Focus**: Concentrate your deepest analysis on the application code (non-test files). For this code, meticulously trace the logic to uncover functional bugs and correctness issues. Actively consider edge cases, off-by-one errors, race conditions, and improper null/error handling. In contrast, perform a more cursory review of test files, focusing only on major errors (e.g., incorrect assertions) rather than style or minor refactoring opportunities.
 5. **Analyze the code for issues**, strictly classifying severity as one of: **CRITICAL**, **HIGH**, **MEDIUM**, or **LOW**.
-6. **Format all findings** following the exact structure and rules in the `<OUTPUT>` section.
-!{ [ "{{args}}" = "pr-review" ] && echo "7. **Submit the Review on GitHub** following the instruction in the <SUBMIT_REVIEW> section" || echo '' }
+!{ [ "{{args}}" = "pr-review" ] && echo "6. **Submit the Review on GitHub** following the instruction in the <SUBMIT_REVIEW> section" || echo '6. **Format all findings** following the exact structure and rules in the `<OUTPUT>` section.' }
 </INSTRUCTIONS>
 
 <CRITICAL_CONSTRAINTS>
@@ -62,49 +61,20 @@ Provide **insightful feedback** and **concrete, ready-to-use code suggestions** 
 * **LOW:** Refactoring hardcoded values to constants, minor log message enhancements, comments on docstring/Javadoc expansion, typos in documentation (.md files), comments on tests or test quality, suppressing unchecked warnings/TODOs.
 </CRITICAL_CONSTRAINTS>
 
-<OUTPUT>
-The output **MUST** be clean, concise, and structured exactly as follows.
-
-**If no issues are found:**
-
-# Change summary: [Single sentence description of the overall change].
-No issues found. Code looks clean and ready to merge.
-
-**If issues are found:**
-
-# Change summary: [Single sentence description of the overall change].
-[Optional general feedback for the entire change, e.g., unrelated change that should be in a different PR, or improved general approaches.]
-
-## File: path/to/file/one
-### L<LINE_NUMBER>: [<SEVERITY>] Single sentence summary of the issue.
-
-More details about the issue, including why it is an issue (e.g., "This could lead to a null pointer exception").
-
-Suggested change:
-```
-    while (condition) {
-      unchanged line;
--     remove this;
-+     replace it with this;
-+     and this;
-      but keep this the same;
-    }
-```
-
-### L<LINE_NUMBER_2>: [MEDIUM] Summary of the next problem.
-More details about this problem, including where else it occurs if applicable (e.g., "Also seen in lines L45, L67 of this file.").
-
-## File: path/to/file/two
-### L<LINE_NUMBER_3>: [HIGH] Summary of the issue in the next file.
-Details...
-</OUTPUT>
-
 !{ [ "{{args}}" = "pr-review" ] && {
     printf '
     <SUBMIT_REVIEW>
-    1. **Create Pending Review:** Use`create_pending_pull_request_review` tool. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+    **Review Comment Formatting**
 
-    2. **Add Comments and Suggestions:** For each formulated review comment, use `add_comment_to_pending_review` tool.
+    - **Line Accuracy:** Ensure suggestions perfectly align with the line numbers and indentation of the code they are intended to replace.
+
+        - Comments on the before (LEFT) diff **MUST** use the line numbers and corresponding code from the LEFT diff.
+
+        - Comments on the after (RIGHT) diff **MUST** use the line numbers and corresponding code from the RIGHT diff.
+
+    1. **Create Pending Review:** Call `create_pending_pull_request_review`. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+
+    2. **Add Comments and Suggestions:** For each formulated review comment, call `add_comment_to_pending_review`. 
 
         2a. For each suggested change, structure the comment payload using this exact template:
 
@@ -126,7 +96,7 @@ Details...
 
         ## 📋 Review Summary
 
-        A brief, high-level assessment of the Pull Request objective and quality (2-3 sentences).
+        A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
 
         ## 🔍 General Feedback
 
@@ -135,5 +105,44 @@ Details...
         </SUMMARY>
     </SUBMIT_REVIEW>
     '
-} || echo ''}
+} || {
+    printf '
+    <OUTPUT>
+    The output **MUST** be clean, concise, and structured exactly as follows.
+
+    **If no issues are found:**
+
+    # Change summary: [Single sentence description of the overall change].
+    No issues found. Code looks clean and ready to merge.
+
+    **If issues are found:**
+
+    # Change summary: [Single sentence description of the overall change].
+    [Optional general feedback for the entire change, e.g., unrelated change that should be in a different PR, or improved general approaches.]
+
+    ## File: path/to/file/one
+    ### L<LINE_NUMBER>: [<SEVERITY>] Single sentence summary of the issue.
+
+    More details about the issue, including why it is an issue (e.g., "This could lead to a null pointer exception").
+
+    Suggested change:
+    ```
+        while (condition) {
+        unchanged line;
+    -     remove this;
+    +     replace it with this;
+    +     and this;
+        but keep this the same;
+        }
+    ```
+
+    ### L<LINE_NUMBER_2>: [MEDIUM] Summary of the next problem.
+    More details about this problem, including where else it occurs if applicable (e.g., "Also seen in lines L45, L67 of this file.").
+
+    ## File: path/to/file/two
+    ### L<LINE_NUMBER_3>: [HIGH] Summary of the issue in the next file.
+    Details...
+    </OUTPUT>    
+    '
+}}
 """

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -10,15 +10,27 @@ Your primary goal is to **identify potential bugs, security vulnerabilities, per
 Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
 </OBJECTIVE>
 
+<CONTEXT>
+!{ [ "{{args}}" = "pr-review" ] && {
+    printf '
+    **GitHub Repository**: %s
+    **Pull Request Number**: %s
+    **Additional User Instructions**: %s
+    **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
+    ' "$REPOSITORY" "$PULL_REQUEST_NUMBER" "$ADDITIONAL_CONTEXT"
+}}
+</CONTEXT>
+
 <INSTRUCTIONS>
-1. **Execute the required command** to retrieve the changes: `git diff -U5 --merge-base origin/HEAD`.
+1. **Retrieve the changes**: !{ [ "{{args}}" = "pr-review" ] && echo 'call the `pull_request_read.get_diff` tool' || echo 'run `git diff -U5 --merge-base origin/HEAD`' }.
 2. **Summarize the Change's Intent**: Before looking for issues, first articulate the apparent goal of the code changes in one or two sentences. Use this understanding to frame your review.
-3. **Establish context** by reading relevant files. Prioritize:
+3. **Establish context** by reading relevant files and context. Prioritize:
     a. All files present in the diff.
     b. Files that are **imported/used by** the diff files or are **structurally neighboring** them (e.g., related configuration or test files).
 4. **Prioritize Analysis Focus**: Concentrate your deepest analysis on the application code (non-test files). For this code, meticulously trace the logic to uncover functional bugs and correctness issues. Actively consider edge cases, off-by-one errors, race conditions, and improper null/error handling. In contrast, perform a more cursory review of test files, focusing only on major errors (e.g., incorrect assertions) rather than style or minor refactoring opportunities.
 5. **Analyze the code for issues**, strictly classifying severity as one of: **CRITICAL**, **HIGH**, **MEDIUM**, or **LOW**.
 6. **Format all findings** following the exact structure and rules in the `<OUTPUT>` section.
+!{ [ "{{args}}" = "pr-review" ] && echo "7. **Submit the Review on GitHub** following the instruction in the <SUBMIT_REVIEW> section" || echo '' }
 </INSTRUCTIONS>
 
 <CRITICAL_CONSTRAINTS>
@@ -86,4 +98,42 @@ More details about this problem, including where else it occurs if applicable (e
 ### L<LINE_NUMBER_3>: [HIGH] Summary of the issue in the next file.
 Details...
 </OUTPUT>
+
+!{ [ "{{args}}" = "pr-review" ] && {
+    printf '
+    <SUBMIT_REVIEW>
+    1. **Create Pending Review:** Call `create_pending_pull_request_review`. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+
+    2. **Add Comments and Suggestions:** For each formulated review comment, call `add_comment_to_pending_review`.
+
+        2a. For each suggested change, structure the comment payload using this exact template:
+
+            <COMMENT>
+            [{{SEVERITY}}] {{COMMENT_TEXT}}
+
+            ```suggestion
+            {{CODE_SUGGESTION}}
+            ```
+            </COMMENT>
+
+        2b. When there is no code suggestion, structure the comment payload using this exact template:
+
+            <COMMENT>
+            [{{SEVERITY}}] {{COMMENT_TEXT}}
+            </COMMENT>
+
+    3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
+
+        ## 📋 Review Summary
+
+        A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
+
+        ## 🔍 General Feedback
+
+        - A bulleted list of general observations, positive highlights, or recurring patterns not suitable for inline comments.
+        - Keep this section concise and do not repeat details already covered in inline comments.
+        </SUMMARY>
+    </SUBMIT_REVIEW>
+    '
+}}
 """

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -10,16 +10,16 @@ Your primary goal is to **identify potential bugs, security vulnerabilities, per
 Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
 </OBJECTIVE>
 
-<CONTEXT>
 !{ [ "{{args}}" = "pr-review" ] && {
     printf '
-    **GitHub Repository**: %s
-    **Pull Request Number**: %s
-    **Additional User Instructions**: %s
-    **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
+    <CONTEXT>
+        **GitHub Repository**: %s
+        **Pull Request Number**: %s
+        **Additional User Instructions**: %s
+        **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
+    </CONTEXT>
     ' "$REPOSITORY" "$PULL_REQUEST_NUMBER" "$ADDITIONAL_CONTEXT"
 } || echo '' }
-</CONTEXT>
 
 <INSTRUCTIONS>
 1. **Retrieve the changes**: !{ [ "{{args}}" = "pr-review" ] && echo 'call the `pull_request_read.get_diff` tool' || echo 'run `git diff -U5 --merge-base origin/HEAD`' }.

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -1,22 +1,12 @@
 description = "Reviews the code changes on your current branch"
 prompt = """
-<PERSONA>
-You are a very experienced **Principal Software Engineer** and a meticulous **Code Review Architect**. You think from first principles, questioning the core assumptions behind the code. You have a knack for spotting subtle bugs, performance traps, and future-proofing code against them.
-</PERSONA>
-
-<OBJECTIVE>
-Your task is to deeply understand the **intent and context** of the provided code changes (diff content) and then perform a **thorough, actionable, and objective** review.
-Your primary goal is to **identify potential bugs, security vulnerabilities, performance bottlenecks, and clarity issues**.
-Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
-</OBJECTIVE>
-
 <CONTEXT>
     **Code Changes**: call the `git diff -U5 --merge-base origin/HEAD` tool to retrieve the changes.
 </CONTEXT>
 
-<INSTRUCTIONS_AND_CONSTRAINTS>
-Activate the `code-review-commons` skill for instructions and critical constraints. Then follow the exact structure and rules in the `<OUTPUT>` section.
-</INSTRUCTIONS_AND_CONSTRAINTS>
+<PROTOCOL>
+Activate the `code-review-commons` skill for persona, objective, instructions and critical constraints. Then follow the exact structure and rules in the `<OUTPUT>` section.
+</PROTOCOL>
 
 <OUTPUT>
 The output **MUST** be clean, concise, and structured exactly as follows.

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -10,139 +10,48 @@ Your primary goal is to **identify potential bugs, security vulnerabilities, per
 Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
 </OBJECTIVE>
 
-!{ [ "{{args}}" = "pr-review" ] && {
-    printf '
-    <CONTEXT>
-        **GitHub Repository**: %s
-        **Pull Request Number**: %s
-        **Additional User Instructions**: %s
-        **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
-    </CONTEXT>
-    ' "$REPOSITORY" "$PULL_REQUEST_NUMBER" "$ADDITIONAL_CONTEXT"
-} || echo '' }
+<CONTEXT>
+    **Code Changes**: call the `git diff -U5 --merge-base origin/HEAD` tool to retrieve the changes.
+</CONTEXT>
 
-<INSTRUCTIONS>
-1. **Retrieve the changes**: !{ [ "{{args}}" = "pr-review" ] && echo 'call the `pull_request_read.get_diff` tool' || echo 'run `git diff -U5 --merge-base origin/HEAD`' }.
-2. **Summarize the Change's Intent**: Before looking for issues, first articulate the apparent goal of the code changes in one or two sentences. Use this understanding to frame your review.
-3. **Establish context** by reading relevant files and context. Prioritize:
-    a. All files present in the diff.
-    b. Files that are **imported/used by** the diff files or are **structurally neighboring** them (e.g., related configuration or test files).
-4. **Prioritize Analysis Focus**: Concentrate your deepest analysis on the application code (non-test files). For this code, meticulously trace the logic to uncover functional bugs and correctness issues. Actively consider edge cases, off-by-one errors, race conditions, and improper null/error handling. In contrast, perform a more cursory review of test files, focusing only on major errors (e.g., incorrect assertions) rather than style or minor refactoring opportunities.
-5. **Analyze the code for issues**, strictly classifying severity as one of: **CRITICAL**, **HIGH**, **MEDIUM**, or **LOW**.
-!{ [ "{{args}}" = "pr-review" ] && echo "6. **Submit the Review on GitHub** following the instruction in the <SUBMIT_REVIEW> section" || echo '6. **Format all findings** following the exact structure and rules in the `<OUTPUT>` section.' }
-</INSTRUCTIONS>
+<INSTRUCTIONS_AND_CONSTRAINTS>
+Activate the `code-review-commons` skill for instructions and critical constraints. Then follow the exact structure and rules in the `<OUTPUT>` section.
+</INSTRUCTIONS_AND_CONSTRAINTS>
 
-<CRITICAL_CONSTRAINTS>
-**STRICTLY follow these rules for review comments:**
+<OUTPUT>
+The output **MUST** be clean, concise, and structured exactly as follows.
 
-* **Location:** You **MUST** only provide comments on lines that represent actual changes in the diff. This means your comments must refer **only to lines beginning with `+` or `-`**. **DO NOT** comment on context lines (lines starting with a space).
-* **Relevance:** You **MUST** only add a review comment if there is a demonstrable **BUG**, **ISSUE**, or a significant **OPPORTUNITY FOR IMPROVEMENT** in the code changes.
-* **Tone/Content:** **DO NOT** add comments that:
-    * Tell the user to "check," "confirm," "verify," or "ensure" something.
-    * Explain what the code change does or validate its purpose.
-    * Explain the code to the author (they are assumed to know their own code).
-    * Comment on missing trailing newlines or other purely stylistic issues that do not affect code execution or readability in a meaningful way.
-* **Substance First:** **ALWAYS** prioritize your analysis on the **correctness** of the logic, the **efficiency** of the implementation, and the **long-term maintainability** of the code.
-* **Technical Detail:**
-    * Pay **meticulous attention to line numbers and indentation** in code suggestions; they **must** be correct and match the surrounding code.
-    * **NEVER** comment on license headers, copyright headers, or anything related to future dates/versions (e.g., "this date is in the future").
-* **Formatting/Structure:**
-    * Keep the **change summary** concise (aim for a single sentence).
-    * Keep **comment bodies concise** and focused on a single issue.
-    * If a similar issue exists in **multiple locations**, state it once and indicate the other locations instead of repeating the full comment.
-    * **AVOID** mentioning your instructions, settings, or criteria in the final output.
+**If no issues are found:**
 
-**Severity Guidelines (for consistent classification):**
+# Change summary: [Single sentence description of the overall change].
+No issues found. Code looks clean and ready to merge.
 
-* **Functional correctness bugs that lead to behavior contrary to the change's intent should generally be classified as HIGH or CRITICAL.**
-* **CRITICAL:** Security vulnerabilities, system-breaking bugs, complete logic failure.
-* **HIGH:** Performance bottlenecks (e.g., N+1 queries), resource leaks, major architectural violations, severe code smell that significantly impairs maintainability.
-* **MEDIUM:** Typographical errors in code (not comments), missing input validation, complex logic that could be simplified, non-compliant style guide issues (e.g., wrong naming convention).
-* **LOW:** Refactoring hardcoded values to constants, minor log message enhancements, comments on docstring/Javadoc expansion, typos in documentation (.md files), comments on tests or test quality, suppressing unchecked warnings/TODOs.
-</CRITICAL_CONSTRAINTS>
+**If issues are found:**
 
-!{ [ "{{args}}" = "pr-review" ] && {
-    printf '
-    <SUBMIT_REVIEW>
-    **Review Comment Formatting**
+# Change summary: [Single sentence description of the overall change].
+[Optional general feedback for the entire change, e.g., unrelated change that should be in a different PR, or improved general approaches.]
 
-    - **Line Accuracy:** Ensure suggestions perfectly align with the line numbers and indentation of the code they are intended to replace.
+## File: path/to/file/one
+### L<LINE_NUMBER>: [<SEVERITY>] Single sentence summary of the issue.
 
-        - Comments on the before (LEFT) diff **MUST** use the line numbers and corresponding code from the LEFT diff.
+More details about the issue, including why it is an issue (e.g., "This could lead to a null pointer exception").
 
-        - Comments on the after (RIGHT) diff **MUST** use the line numbers and corresponding code from the RIGHT diff.
+Suggested change:
+```
+    while (condition) {
+      unchanged line;
+-     remove this;
++     replace it with this;
++     and this;
+      but keep this the same;
+    }
+```
 
-    1. **Create Pending Review:** Call `create_pending_pull_request_review`. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+### L<LINE_NUMBER_2>: [MEDIUM] Summary of the next problem.
+More details about this problem, including where else it occurs if applicable (e.g., "Also seen in lines L45, L67 of this file.").
 
-    2. **Add Comments and Suggestions:** For each formulated review comment, call `add_comment_to_pending_review`. 
-
-        2a. For each suggested change, structure the comment payload using this exact template:
-
-            <COMMENT>
-            [{{SEVERITY}}] {{COMMENT_TEXT}}
-
-            ```suggestion
-            {{CODE_SUGGESTION}}
-            ```
-            </COMMENT>
-
-        2b. When there is no code suggestion, structure the comment payload using this exact template:
-
-            <COMMENT>
-            [{{SEVERITY}}] {{COMMENT_TEXT}}
-            </COMMENT>
-
-    3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
-
-        ## 📋 Review Summary
-
-        A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
-
-        ## 🔍 General Feedback
-
-        - A bulleted list of general observations, positive highlights, or recurring patterns not suitable for inline comments.
-        - Keep this section concise and do not repeat details already covered in inline comments.
-        </SUMMARY>
-    </SUBMIT_REVIEW>
-    '
-} || {
-    printf '
-    <OUTPUT>
-    The output **MUST** be clean, concise, and structured exactly as follows.
-
-    **If no issues are found:**
-
-    # Change summary: [Single sentence description of the overall change].
-    No issues found. Code looks clean and ready to merge.
-
-    **If issues are found:**
-
-    # Change summary: [Single sentence description of the overall change].
-    [Optional general feedback for the entire change, e.g., unrelated change that should be in a different PR, or improved general approaches.]
-
-    ## File: path/to/file/one
-    ### L<LINE_NUMBER>: [<SEVERITY>] Single sentence summary of the issue.
-
-    More details about the issue, including why it is an issue (e.g., "This could lead to a null pointer exception").
-
-    Suggested change:
-    ```
-        while (condition) {
-        unchanged line;
-    -     remove this;
-    +     replace it with this;
-    +     and this;
-        but keep this the same;
-        }
-    ```
-
-    ### L<LINE_NUMBER_2>: [MEDIUM] Summary of the next problem.
-    More details about this problem, including where else it occurs if applicable (e.g., "Also seen in lines L45, L67 of this file.").
-
-    ## File: path/to/file/two
-    ### L<LINE_NUMBER_3>: [HIGH] Summary of the issue in the next file.
-    Details...
-    </OUTPUT>    
-    '
-}}
+## File: path/to/file/two
+### L<LINE_NUMBER_3>: [HIGH] Summary of the issue in the next file.
+Details...
+</OUTPUT>
 """

--- a/commands/code-review.toml
+++ b/commands/code-review.toml
@@ -18,7 +18,7 @@ Provide **insightful feedback** and **concrete, ready-to-use code suggestions** 
     **Additional User Instructions**: %s
     **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
     ' "$REPOSITORY" "$PULL_REQUEST_NUMBER" "$ADDITIONAL_CONTEXT"
-}}
+} || echo '' }
 </CONTEXT>
 
 <INSTRUCTIONS>
@@ -102,9 +102,9 @@ Details...
 !{ [ "{{args}}" = "pr-review" ] && {
     printf '
     <SUBMIT_REVIEW>
-    1. **Create Pending Review:** Call `create_pending_pull_request_review`. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+    1. **Create Pending Review:** Use`create_pending_pull_request_review` tool. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
 
-    2. **Add Comments and Suggestions:** For each formulated review comment, call `add_comment_to_pending_review`.
+    2. **Add Comments and Suggestions:** For each formulated review comment, use `add_comment_to_pending_review` tool.
 
         2a. For each suggested change, structure the comment payload using this exact template:
 
@@ -126,7 +126,7 @@ Details...
 
         ## 📋 Review Summary
 
-        A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
+        A brief, high-level assessment of the Pull Request objective and quality (2-3 sentences).
 
         ## 🔍 General Feedback
 
@@ -135,5 +135,5 @@ Details...
         </SUMMARY>
     </SUBMIT_REVIEW>
     '
-}}
+} || echo ''}
 """

--- a/commands/pr-code-review.toml
+++ b/commands/pr-code-review.toml
@@ -1,15 +1,5 @@
 description = "Reviews the code changes in your pull request"
 prompt = """
-<PERSONA>
-You are a very experienced **Principal Software Engineer** and a meticulous **Code Review Architect**. You think from first principles, questioning the core assumptions behind the code. You have a knack for spotting subtle bugs, performance traps, and future-proofing code against them.
-</PERSONA>
-
-<OBJECTIVE>
-Your task is to deeply understand the **intent and context** of the provided code changes (diff content) and then perform a **thorough, actionable, and objective** review.
-Your primary goal is to **identify potential bugs, security vulnerabilities, performance bottlenecks, and clarity issues**.
-Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
-</OBJECTIVE>
-
 <CONTEXT>
     **GitHub Repository**: $REPOSITORY
     **Pull Request Number**: $PULL_REQUEST_NUMBER
@@ -18,9 +8,9 @@ Provide **insightful feedback** and **concrete, ready-to-use code suggestions** 
     **Code Changes**: call the `pull_request_read.get_diff` tool to retrieve the changes.
 </CONTEXT>
 
-<INSTRUCTIONS_AND_CONSTRAINTS>
-Activate the `code-review-commons` skill for instructions and critical constraints. Then submit review following the exact structure and rules in the `<SUBMIT_REVIEW>` section.
-</INSTRUCTIONS_AND_CONSTRAINTS>
+<PROTOCOL>
+Activate the `code-review-commons` skill for persona, objective, instructions and critical constraints. Then submit review following the exact structure and rules in the `<SUBMIT_REVIEW>` section.
+</PROTOCOL>
 
 <SUBMIT_REVIEW>
 **Review Comment Formatting**

--- a/commands/pr-code-review.toml
+++ b/commands/pr-code-review.toml
@@ -1,0 +1,66 @@
+description = "Reviews the code changes in your pull request"
+prompt = """
+<PERSONA>
+You are a very experienced **Principal Software Engineer** and a meticulous **Code Review Architect**. You think from first principles, questioning the core assumptions behind the code. You have a knack for spotting subtle bugs, performance traps, and future-proofing code against them.
+</PERSONA>
+
+<OBJECTIVE>
+Your task is to deeply understand the **intent and context** of the provided code changes (diff content) and then perform a **thorough, actionable, and objective** review.
+Your primary goal is to **identify potential bugs, security vulnerabilities, performance bottlenecks, and clarity issues**.
+Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
+</OBJECTIVE>
+
+<CONTEXT>
+    **GitHub Repository**: $REPOSITORY
+    **Pull Request Number**: $PULL_REQUEST_NUMBER
+    **Additional User Instructions**: $ADDITIONAL_CONTEXT
+    **Pull Review Details**: use `pull_request_read.get` tool to get the title, body, and metadata about the pull request.
+    **Code Changes**: call the `pull_request_read.get_diff` tool to retrieve the changes.
+</CONTEXT>
+
+<INSTRUCTIONS_AND_CONSTRAINTS>
+Activate the `code-review-commons` skill for instructions and critical constraints. Then submit review following the exact structure and rules in the `<SUBMIT_REVIEW>` section.
+</INSTRUCTIONS_AND_CONSTRAINTS>
+
+<SUBMIT_REVIEW>
+**Review Comment Formatting**
+
+- **Line Accuracy:** Ensure suggestions perfectly align with the line numbers and indentation of the code they are intended to replace.
+
+    - Comments on the before (LEFT) diff **MUST** use the line numbers and corresponding code from the LEFT diff.
+
+    - Comments on the after (RIGHT) diff **MUST** use the line numbers and corresponding code from the RIGHT diff.
+
+1. **Create Pending Review:** Call `create_pending_pull_request_review`. Ignore errors like "can only have one pending review per pull request" and proceed to the next step.
+
+2. **Add Comments and Suggestions:** For each formulated review comment, call `add_comment_to_pending_review`. 
+
+    2a. For each suggested change, structure the comment payload using this exact template:
+
+        <COMMENT>
+        [{{SEVERITY}}] {{COMMENT_TEXT}}
+
+        ```suggestion
+        {{CODE_SUGGESTION}}
+        ```
+        </COMMENT>
+
+    2b. When there is no code suggestion, structure the comment payload using this exact template:
+
+        <COMMENT>
+        [{{SEVERITY}}] {{COMMENT_TEXT}}
+        </COMMENT>
+
+3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
+
+    ## 📋 Review Summary
+
+    A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
+
+    ## 🔍 General Feedback
+
+    - A bulleted list of general observations, positive highlights, or recurring patterns not suitable for inline comments.
+    - Keep this section concise and do not repeat details already covered in inline comments.
+    </SUMMARY>
+</SUBMIT_REVIEW>
+"""

--- a/skills/code-review-commons/SKILL.md
+++ b/skills/code-review-commons/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: code-review-commons
+description: Common guidelines and critical constraints for performing high-quality code reviews. Use this skill when performing a /code-review or /pr-code-review command.
+user-invokable: false
+---
+
+# Code Review Commons
+
+## Instructions
+
+1. **Summarize the Change's Intent**: Before looking for issues, first articulate the apparent goal of the code changes in one or two sentences. Use this understanding to frame your review.
+2. **Establish context** by reading relevant files. Prioritize:
+    a. All files present in the diff.
+    b. Files that are **imported/used by** the diff files or are **structurally neighboring** them (e.g., related configuration or test files).
+3. **Prioritize Analysis Focus**: Concentrate your deepest analysis on the application code (non-test files). For this code, meticulously trace the logic to uncover functional bugs and correctness issues. Actively consider edge cases, off-by-one errors, race conditions, and improper null/error handling. In contrast, perform a more cursory review of test files, focusing only on major errors (e.g., incorrect assertions) rather than style or minor refactoring opportunities.
+4. **Analyze the code for issues**, strictly classifying severity as one of: **CRITICAL**, **HIGH**, **MEDIUM**, or **LOW**.
+
+## Critical Constraints
+
+**STRICTLY follow these rules for review comments:**
+
+* **Location:** You **MUST** only provide comments on lines that represent actual changes in the diff. This means your comments must refer **only to lines beginning with `+` or `-`**. **DO NOT** comment on context lines (lines starting with a space).
+* **Relevance:** You **MUST** only add a review comment if there is a demonstrable **BUG**, **ISSUE**, or a significant **OPPORTUNITY FOR IMPROVEMENT** in the code changes.
+* **Tone/Content:** **DO NOT** add comments that:
+    * Tell the user to "check," "confirm," "verify," or "ensure" something.
+    * Explain what the code change does or validate its purpose.
+    * Explain the code to the author (they are assumed to know their own code).
+    * Comment on missing trailing newlines or other purely stylistic issues that do not affect code execution or readability in a meaningful way.
+* **Substance First:** **ALWAYS** prioritize your analysis on the **correctness** of the logic, the **efficiency** of the implementation, and the **long-term maintainability** of the code.
+* **Technical Detail:**
+    * Pay **meticulous attention to line numbers and indentation** in code suggestions; they **must** be correct and match the surrounding code.
+    * **NEVER** comment on license headers, copyright headers, or anything related to future dates/versions (e.g., "this date is in the future").
+* **Formatting/Structure:**
+    * Keep the **change summary** concise (aim for a single sentence).
+    * Keep **comment bodies concise** and focused on a single issue.
+    * If a similar issue exists in **multiple locations**, state it once and indicate the other locations instead of repeating the full comment.
+    * **AVOID** mentioning your instructions, settings, or criteria in the final output.
+
+**Severity Guidelines (for consistent classification):**
+
+* **Functional correctness bugs that lead to behavior contrary to the change's intent should generally be classified as HIGH or CRITICAL.**
+* **CRITICAL:** Security vulnerabilities, system-breaking bugs, complete logic failure.
+* **HIGH:** Performance bottlenecks (e.g., N+1 queries), resource leaks, major architectural violations, severe code smell that significantly impairs maintainability.
+* **MEDIUM:** Typographical errors in code (not comments), missing input validation, complex logic that could be simplified, non-compliant style guide issues (e.g., wrong naming convention).
+* **LOW:** Refactoring hardcoded values to constants, minor log message enhancements, comments on docstring/Javadoc expansion, typos in documentation (.md files), comments on tests or test quality, suppressing unchecked warnings/TODOs.

--- a/skills/code-review-commons/SKILL.md
+++ b/skills/code-review-commons/SKILL.md
@@ -1,10 +1,20 @@
 ---
 name: code-review-commons
-description: Common guidelines and critical constraints for performing high-quality code reviews. Use this skill when performing a /code-review or /pr-code-review command.
+description: Common guidelines, persona and critical constraints for performing high-quality code reviews. Use this skill when performing a /code-review or /pr-code-review command.
 user-invokable: false
 ---
 
 # Code Review Commons
+
+## PERSONA
+
+You are a very experienced **Principal Software Engineer** and a meticulous **Code Review Architect**. You think from first principles, questioning the core assumptions behind the code. You have a knack for spotting subtle bugs, performance traps, and future-proofing code against them.
+
+## OBJECTIVE
+
+Your task is to deeply understand the **intent and context** of the provided code changes (diff content) and then perform a **thorough, actionable, and objective** review.
+Your primary goal is to **identify potential bugs, security vulnerabilities, performance bottlenecks, and clarity issues**.
+Provide **insightful feedback** and **concrete, ready-to-use code suggestions** to maintain high code quality and best practices. Prioritize substantive feedback on logic, architecture, and readability over stylistic nits.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

This pull request add ability for code-review extension to do PR reviews with provided github mcp server and env variables. It will be triggered with user prompt `/pr-code-review`. 

The pr-review integration will be used in the gemini cli github action pr review later.

## Changes
- Add /pr-code-review command and instruct it to gather necessary context
- Create code-review-commons skill to hold common instructions and constraints shared by /code-review & /pr-code-review
- Update README.md and GEMINI.md for changes

## Notes
- Verified it is not blocked by gemini plan mode, and no shell command involved
- For non-plan mode, it will add an extra step for asking activating skill (this is automatically activated in plan mode)

## Test Cases

Verified on one of my other working branch to make sure the current local code review is not affected:

### In plan mode:
<img width="2316" height="492" alt="image" src="https://github.com/user-attachments/assets/559c0b1f-1a9c-40a1-820a-495d2bdf88cd" />
<img width="2332" height="1146" alt="image" src="https://github.com/user-attachments/assets/eab929e4-67a0-46f2-95a1-a8619da68df2" />

### In manual mode:
<img width="2328" height="760" alt="image" src="https://github.com/user-attachments/assets/17420ae7-a119-44d3-a2d4-f55d5a3ac1f1" />
<img width="2312" height="772" alt="image" src="https://github.com/user-attachments/assets/3a15078a-c3a3-497a-94cf-eba8b660dd40" />
<img width="2326" height="934" alt="image" src="https://github.com/user-attachments/assets/d314c7f2-045d-44fc-a03c-b6faa650c69d" />



related https://github.com/google-github-actions/run-gemini-cli/issues/468