### PR TITLE
fix: remove unmatched closing SUMMARY tag

### DIFF
--- a/commands/pr-code-review.toml
+++ b/commands/pr-code-review.toml
@@ -51,6 +51,5 @@ Activate the `code-review-commons` skill for persona, objective, instructions an
 
     - A bulleted list of general observations, positive highlights, or recurring patterns not suitable for inline comments.
     - Keep this section concise and do not repeat details already covered in inline comments.
-    </SUMMARY>
 </SUBMIT_REVIEW>
 """


### PR DESCRIPTION
## Summary

This PR proposes removing an unmatched `</SUMMARY>` tag from the summary comment template in `commands/pr-code-review.toml`.

Since there is no corresponding opening `<SUMMARY>` tag and the surrounding instructions are already delimited by `<SUBMIT_REVIEW>` and `</SUBMIT_REVIEW>`, the closing tag appears to be unnecessary. 

I considered adding a matching `<SUMMARY>` tag for consistency with the existing `<COMMENT>` wrappers.
However, because this section describes the exact Markdown format for the generated review summary, I chose to remove the unmatched closing tag rather than introduce wrapper markup that could be copied into the final comment.

Removing it keeps the summary template unambiguous and reduces the chance of unintended markup appearing in the generated review summary.

## Changes

- Remove the unmatched `</SUMMARY>` tag from the `/pr-code-review` prompt.
- Leave the existing summary Markdown format unchanged.

## Testing

- Verified that the summary template remains clearly scoped within the `<SUBMIT_REVIEW>` section.
- No runtime logic or tool configuration is changed.